### PR TITLE
修复了部分train.py，utils.py和config文件的bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 * SwanLab：[https://swanlab.cn/@ShaohonChen/Qwen3-SmVL/overview](https://swanlab.cn/@ShaohonChen/Qwen3-SmVL/overview)
 * 数据集：[https://huggingface.co/datasets/HuggingFaceM4/the_cauldron](https://huggingface.co/datasets/HuggingFaceM4/the_cauldron)
 
+<div style="background-color:#d4edda; color:black; padding:10px; border-radius:4px; border:1px solid #7bd886ff; width: 90%; max-width: 100%; margin: auto;">
+  😊特别感谢 <a href="https://github.com/zhihuazhao-bit" target="_blank" style="color:#00562b; font-weight:bold; text-decoration:underline;">@zhihuazhao-bit</a> 帮我审阅和修复了代码中众多的小bug，并在NV上完成了测试。
+</div>
+
 ## 摘要
 
 最近Huggingface团队发布了超小多模态模型SmolVLM2，可以做到端侧1GB显存推理。在怀着惊喜试用后发现，虽然模型有极其强大的视觉文本理解能力，但是模型却无法理解中文。这对一个“四六级压线过”的笔者来说十分不友好。刚好前段时间做SwanLab硬件检测适配时有一台未到期的沐曦曦云C500服务器，因此萌生了使用**沐曦GPU芯片**微调、把当前中文小模型扛把子Qwen3与SmolVLM2直接微调拼接的想法。
@@ -608,7 +612,7 @@ bash download_resource.sh
 # 单GPU训练
 CUDA_VISIBLE_DEVICES=0 python train.py ./cocoqa_train.yaml
 # 8GPU训练
-accelerate --num_process 8 train.py ./cocoqa_train.yaml
+accelerate launch --num_process 8 train.py ./cocoqa_train.yaml
 ```
 
 注意，本项目使用SwanLab进行训练日志记录与分析，如果未登陆SwanLab需要使用`swanlab login`进行登陆。运行后看到如下结果即代表实验成功开启：

--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ PS: 作者公开了在[SwanLab上的训练结果](https://swanlab.cn/@ShaohonChe
 # 单GPU训练
 CUDA_VISIBLE_DEVICES=0 python train.py ./full_train.yaml
 # 8GPU训练
-accelerate --num_process 8 train.py ./full_train.yaml
+accelerate launch --num_processes 8 train.py ./full_train.yaml
 ```
 
 下图展示了使用完整微调数据对比于小批量训练，可以看到全量数据微调时loss变得更为抖动，这是由于数据类型的丰富给模型的学习带来了一定的挑战。

--- a/cocoqa_train.yaml
+++ b/cocoqa_train.yaml
@@ -6,7 +6,7 @@ per_device_train_batch_size: 1
 gradient_accumulation_steps: 4
 dataloader_pin_memory: False
 warmup_ratio: 0.1
-learning_rate: 1e-4
+learning_rate: 0.0001
 lr_scheduler_type: "cosine"
 weight_decay: 0.01
 logging_steps: 5

--- a/full_train.yaml
+++ b/full_train.yaml
@@ -1,20 +1,19 @@
 train_data: "all"
 seed: 42
 data_seed: 42
-max_steps: null
-num_train_epochs=1
+num_train_epochs: 1
 per_device_train_batch_size: 1
 gradient_accumulation_steps: 4
 dataloader_pin_memory: False
 warmup_ratio: 0.1
-learning_rate: 1e-4
+learning_rate: 0.0001
 lr_scheduler_type: "cosine"
 weight_decay: 0.01
 logging_steps: 5
 eval_strategy: "steps"
-eval_steps: 0.125
+eval_steps: 50
 save_strategy: "steps"
-save_steps: 0.125
+save_steps: 100
 save_total_limit: 8
 optim: "adamw_torch"
 bf16: True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-torch
-torchvision
-transformers
-accelerate
-modelscope
-datasets
-num2words
-swanlab
+datasets==4.0.0
+Pillow==11.3.0
+swanlab==0.6.8
+torch==2.7.1
+transformers==4.54.0
+accelerate==1.9.0
+num2words==0.5.14
+modelscope==1.28.1

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import torch
 from transformers import (
@@ -51,8 +51,8 @@ def load_model(device="cuda:0"):
     @dataclass
     class ConnectConfig:
         scale_factor: int = 4
-        vision_config: VisionConfig = VisionConfig()
-        text_config: TextConfig = TextConfig()
+        vision_config: VisionConfig = field(default_factory=VisionConfig)
+        text_config: TextConfig = field(default_factory=TextConfig)
 
     new_connector_config = ConnectConfig()
 


### PR DESCRIPTION
主要修改如下：
1. 修复mian入口处，参数初始化为parser = HfArgumentParser(MyTrainArgs)
2. 修改cocoqa_train.yaml和full_train.yaml中learning_rate: 1e-4为0.0001，解决参数初始化时float和str类型无法比较的问题。
3. 删除full_train.yaml和train.py中的max_steps参数，因为若在config文件中将max_steps:null，在参数初始化时会出现类型错误问题。
4. 修复full_train.yaml中，num_train_epochs=1为num_train_epochs: 1
5. 修改class MyTrainArgs(TrainingArguments)中的参数命名问题。
6. 修复def load_mm_data(select_data)函数中，select_data变量被重新赋值，使数据采样失效的问题。
7. 修复Interference时，图片资源路径：images = [[Image.open("./resource/dog.png")]]和参数padding_side